### PR TITLE
more complete change for both iOS 5 & iOS 6

### DIFF
--- a/FPPopoverController.m
+++ b/FPPopoverController.m
@@ -161,6 +161,12 @@
 
 #pragma mark Orientation
 
+-(BOOL)shouldAutorotate {
+	if ([_viewController respondsToSelector:@selector(shouldAutorotate)])
+		return [_viewController shouldAutorotate];
+	return YES;
+}
+
 -(BOOL)shouldAutorotateToInterfaceOrientation:(UIInterfaceOrientation)toInterfaceOrientation
 {
 	if ([_viewController respondsToSelector:@selector(shouldAutorotateToInterfaceOrientation:)])
@@ -304,34 +310,42 @@
 	_deviceOrientation = [UIDevice currentDevice].orientation;
 
 	BOOL shouldResetView = NO;
-
-    //iOS6 has a new orientation implementation.
-    //we ask to reset the view if is >= 6.0
-	if ([_viewController respondsToSelector:@selector(shouldAutorotateToInterfaceOrientation:)] &&
-        [[[UIDevice currentDevice] systemVersion] floatValue] < 6.0)
+	UIInterfaceOrientation interfaceOrientation;
+	switch (_deviceOrientation)
 	{
-		UIInterfaceOrientation interfaceOrientation;
-		switch (_deviceOrientation)
+		case UIDeviceOrientationLandscapeLeft:
+			interfaceOrientation = UIInterfaceOrientationLandscapeLeft;
+			break;
+		case UIDeviceOrientationLandscapeRight:
+			interfaceOrientation = UIInterfaceOrientationLandscapeRight;
+			break;
+		case UIDeviceOrientationPortrait:
+			interfaceOrientation = UIInterfaceOrientationPortrait;
+			break;
+		case UIDeviceOrientationPortraitUpsideDown:
+			interfaceOrientation = UIInterfaceOrientationPortraitUpsideDown;
+			break;
+		default:
+			return;	// just ignore face up / face down, etc.
+	}
+	if (_viewController.interfaceOrientation == interfaceOrientation)
+		return;
+
+#if __IPHONE_OS_VERSION_MIN_REQUIRED < __IPHONE_6_0
+	if ([[[UIDevice currentDevice] systemVersion] floatValue] < 6.0)
+	{
+		if ([_viewController
+			 respondsToSelector:@selector(shouldAutorotateToInterfaceOrientation:)])
 		{
-			case UIDeviceOrientationLandscapeLeft:
-				interfaceOrientation = UIInterfaceOrientationLandscapeLeft;
-				break;
-			case UIDeviceOrientationLandscapeRight:
-				interfaceOrientation = UIInterfaceOrientationLandscapeRight;
-				break;
-			case UIDeviceOrientationPortrait:
-				interfaceOrientation = UIInterfaceOrientationPortrait;
-				break;
-			case UIDeviceOrientationPortraitUpsideDown:
-				interfaceOrientation = UIInterfaceOrientationPortraitUpsideDown;
-				break;
-			default:
-				return;	// just ignore face up / face down, etc.
+			shouldResetView
+			  = [_viewController shouldAutorotateToInterfaceOrientation:interfaceOrientation];
 		}
 	}
 	else
+#endif
 	{
-		shouldResetView = YES;
+		if ([_viewController respondsToSelector:@selector(shouldAutorotate)])
+			shouldResetView = [_viewController shouldAutorotate];
 	}
 
 	if (shouldResetView)


### PR DESCRIPTION
previous pull request for this actually was doing the right thing to differentiate between iOS5 and iOS6 by relying on whether
respondsToSelector:@selector(shouldAutorotateToInterfaceOrientation:)

in the code that you modified after accepting the pull request, it stopped working.

i have tried to re-fashion this pull-request so the logic is clearer about what's going on.  in terms of logic, it's almost exactly the same as the previous pull-request, but it's been unwound a bit so you can tell what is iOS5 based and what is iOS6 based.
