### PR TITLE
minor: redundant call to set _touchView autoresizingMask & clipsToBounds

### DIFF
--- a/FPPopoverController.m
+++ b/FPPopoverController.m
@@ -109,9 +109,6 @@
         self.view.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         self.view.clipsToBounds = NO;
 
-        _touchView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
-        _touchView.clipsToBounds = NO;
-        
         //setting contentview
         _contentView.title = _viewController.title;
         _contentView.clipsToBounds = NO;


### PR DESCRIPTION
note that prior to the diffs, these items were being set twice.  a very minor change.
