### PR TITLE
fix an issue where leaving the app & coming back in would ignore keyboard

### DIFF
--- a/FPPopoverController.m
+++ b/FPPopoverController.m
@@ -88,8 +88,9 @@
         _touchView.backgroundColor = [UIColor clearColor];
         _touchView.autoresizingMask = UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight;
         _touchView.clipsToBounds = NO;
+		[_touchView becomeFirstResponder];
         [self.view addSubview:_touchView];
-		
+
         __block typeof (self) bself = self;
         [_touchView setTouchedOutsideBlock:^{
             [bself dismissPopoverAnimated:YES];
@@ -99,9 +100,8 @@
 
         _contentView = [[FPPopoverView alloc] initWithFrame:CGRectMake(0, 0, 
                                               self.contentSize.width, self.contentSize.height)];
-        
         _viewController = viewController;
-        
+
         [_touchView addSubview:_contentView];
         
         [_contentView addContentView:_viewController.view];

--- a/FPTouchView.m
+++ b/FPTouchView.m
@@ -10,7 +10,6 @@
 
 @implementation FPTouchView
 
-
 -(void)setTouchedOutsideBlock:(FPTouchedOutsideBlock)outsideBlock
 {
     _outsideBlock = outsideBlock;
@@ -19,6 +18,11 @@
 -(void)setTouchedInsideBlock:(FPTouchedInsideBlock)insideBlock
 {
     _insideBlock = insideBlock;
+}
+
+- (BOOL)canBecomeFirstResponder
+{
+	return YES;
 }
 
 -(UIView*)hitTest:(CGPoint)point withEvent:(UIEvent *)event
@@ -45,7 +49,7 @@
         {
             _insideBlock();
         }
-        else if(!touchedInside && _outsideBlock)
+        else if(self.isFirstResponder && !touchedInside && _outsideBlock)
         {
             _outsideBlock();
         }


### PR DESCRIPTION
i have run into a problem whereby, when the FPPopoverController's context is a ViewController controlling a textView, leaving the app and then coming back in causes the FPTouchView to respond to touches on the keyboard because it would call the outsideBlock() which dismisses the popover.

this change just sets the first-responder chain, and so if the content VC has a firstResponder, it will help FPTouchView skip the dismiss call.
