### PR TITLE
Fix compile errors

### DIFF
--- a/ARCMacros.h
+++ b/ARCMacros.h
@@ -59,4 +59,5 @@
     #define SAFE_ARC_AUTORELEASE_POOL_END() [pool release];
 #endif
 
-
+#define FPPopoverWeakObject(o) __block __typeof__((__typeof__(o))o)
+#define FPPopoverWeakSelf FPPopoverWeakObject(self)

--- a/FPPopoverController.m
+++ b/FPPopoverController.m
@@ -120,8 +120,7 @@
         _touchView.clipsToBounds = NO;
         [self.view addSubview:_touchView];
         
-        
-        __block typeof (self) bself = self;
+        FPPopoverWeakSelf bself = self;
         [_touchView setTouchedOutsideBlock:^{
             [bself dismissPopoverAnimated:YES];
         }];


### PR DESCRIPTION
The compiler fails to understand the typeof (self) syntax:

FPPopover/FPPopoverController.m:124:17: warning: type specifier missing,
defaults to 'int' [-Wimplicit-int]
        __block typeof (self) bself = self;
        ~~~~~~~ ^
FPPopover/FPPopoverController.m:124:25:
error: a parameter list without types is only allowed in a function definition
        __block typeof (self) bself = self;
                        ^
FPPopover/FPPopoverController.m:124:30:
error: expected ';' at end of declaration
        __block typeof (self) bself = self;

I fixed this by following the advice found at
http://stackoverflow.com/a/10921206/1147607
