### PR TITLE
Remove method never read (reported by Xcode Analyze)

### DIFF
--- a/FPPopoverController.m
+++ b/FPPopoverController.m
@@ -277,7 +277,7 @@
 
 -(CGPoint)originFromView:(UIView*)fromView
 {
-    CGPoint p;
+    CGPoint p = CGPointZero;
     if([_contentView arrowDirection] == FPPopoverArrowDirectionUp ||
        [_contentView arrowDirection] == FPPopoverNoArrow)
     {
@@ -311,6 +311,7 @@
 
 -(void)dismissPopover
 {
+    [self.touchView removeFromSuperview];
     [self.view removeFromSuperview];
     if([self.delegate respondsToSelector:@selector(popoverControllerDidDismissPopover:)])
     {
@@ -365,24 +366,24 @@
 	if ([_viewController respondsToSelector:@selector(shouldAutorotateToInterfaceOrientation:)] &&
         [[[UIDevice currentDevice] systemVersion] floatValue] < 6.0)
 	{
-		UIInterfaceOrientation interfaceOrientation;
-		switch (_deviceOrientation)
-		{
-			case UIDeviceOrientationLandscapeLeft:
-				interfaceOrientation = UIInterfaceOrientationLandscapeLeft;
-				break;
-			case UIDeviceOrientationLandscapeRight:
-				interfaceOrientation = UIInterfaceOrientationLandscapeRight;
-				break;
-			case UIDeviceOrientationPortrait:
-				interfaceOrientation = UIInterfaceOrientationPortrait;
-				break;
-			case UIDeviceOrientationPortraitUpsideDown:
-				interfaceOrientation = UIInterfaceOrientationPortraitUpsideDown;
-				break;
-			default:
-				return;	// just ignore face up / face down, etc.
-		}
+        //		UIInterfaceOrientation interfaceOrientation;
+        //		switch (_deviceOrientation)
+        //		{
+        //			case UIDeviceOrientationLandscapeLeft:
+        //				interfaceOrientation = UIInterfaceOrientationLandscapeLeft;
+        //				break;
+        //			case UIDeviceOrientationLandscapeRight:
+        //				interfaceOrientation = UIInterfaceOrientationLandscapeRight;
+        //				break;
+        //			case UIDeviceOrientationPortrait:
+        //				interfaceOrientation = UIInterfaceOrientationPortrait;
+        //				break;
+        //			case UIDeviceOrientationPortraitUpsideDown:
+        //				interfaceOrientation = UIInterfaceOrientationPortraitUpsideDown;
+        //				break;
+        //			default:
+        //				return;	// just ignore face up / face down, etc.
+        //		}
 	}
 	else
 	{
@@ -424,14 +425,14 @@
     // thanks @Niculcea
     // If we presentFromPoint with _fromView nil will calculate based on self.orgin with 2x2 size.
     // Fix for presentFromPoint from avolovoy's FPPopover fork
-    float width = 2.0f;
-    float height = 2.0f;
+    //float width = 2.0f;
+    //float height = 2.0f;
     CGPoint p = CGPointMake(self.origin.x, self.origin.y);
     
     if (v != nil) {
         p = [v.superview convertPoint:v.frame.origin toView:self.view];
-        width = v.frame.size.width;
-        height = v.frame.size.height;
+        //width = v.frame.size.width;
+        //height = v.frame.size.height;
     }
     
     


### PR DESCRIPTION
Discussed methods never read, and adding the removal (removeFromSubView) of FPTouchView, in this way is called the method of dealloc to dismiss the popover
