### PR TITLE
Fixed FPPopoverWhiteTint top edge not being applied tint issue

### DIFF
--- a/FPPopoverView.m
+++ b/FPPopoverView.m
@@ -338,7 +338,7 @@
     else if(self.tint == FPPopoverWhiteTint)
     {
         colors[0] = colors[1] = colors[2] = 1.0;
-        colors[0] = colors[1] = colors[2] = 1.0;
+        colors[4] = colors[5] = colors[6] = 1.0;
         colors[3] = colors[7] = 1.0;
     }
     


### PR DESCRIPTION
Using FPPopover, noticed top rounded edge was remaining default colour (black) when tint set to FPPopoverWhiteTint, due to a small bug in FPPopoverView.m. Found and fixed.
