### PR TITLE
fix bug when tint=FPPopoverWhiteTint

### DIFF
--- a/FPPopoverView.m
+++ b/FPPopoverView.m
@@ -338,7 +338,7 @@
     else if(self.tint == FPPopoverWhiteTint)
     {
         colors[0] = colors[1] = colors[2] = 1.0;
-        colors[0] = colors[1] = colors[2] = 1.0;
+        colors[4] = colors[5] = colors[6] = 1.0;
         colors[3] = colors[7] = 1.0;
     }
     


### PR DESCRIPTION
It's a bug when tint use FPPopoverWhiteTine, the arrow not set to white color
