### PR TITLE
Fixing colors for FPPopoverWhiteTint

### DIFF
--- a/FPPopoverView.m
+++ b/FPPopoverView.m
@@ -338,7 +338,7 @@
     else if(self.tint == FPPopoverWhiteTint)
     {
         colors[0] = colors[1] = colors[2] = 1.0;
-        colors[0] = colors[1] = colors[2] = 1.0;
+        colors[4] = colors[5] = colors[6] = 1.0;
         colors[3] = colors[7] = 1.0;
     }
     
@@ -512,6 +512,12 @@
     _contentView.frame = contentRect;
     _titleLabel.text = self.title;    
     
+    if (self.tint == FPPopoverWhiteTint) {
+        _titleLabel.textColor = [UIColor blackColor];
+    }
+    else {
+        _titleLabel.textColor = [UIColor whiteColor];
+    }
 }
 
 


### PR DESCRIPTION
Gradient colors were set incorrectly in the white tint case. Plus, set the title text color to black (instead of white) so it will show up.
